### PR TITLE
fix: 親(webrtc)死亡時に janus も終了するよう PR_SET_PDEATHSIG を設定

### DIFF
--- a/janus.c
+++ b/janus.c
@@ -22,6 +22,10 @@
 #include <signal.h>
 #include <getopt.h>
 #include <sys/resource.h>
+#include <unistd.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <poll.h>
@@ -4187,6 +4191,19 @@ gboolean janus_plugin_auth_signature_contains(janus_plugin *plugin, const char *
 /* Main */
 gint main(int argc, char *argv[])
 {
+#ifdef __linux__
+	/* Die together with our parent (the webrtc edge app). If webrtc exits or
+	 * is SIGKILL'd, the kernel sends us SIGKILL too, instead of leaving this
+	 * janus orphaned to init and running forever. On long WAN-offline runs
+	 * such orphaned janus (and their unreaped children) accumulate until the
+	 * process/thread limit is exhausted. getppid()==1 closes the race where
+	 * the parent already died before PDEATHSIG was armed. */
+	prctl(PR_SET_PDEATHSIG, SIGKILL);
+	if(getppid() == 1) {
+		exit(1);
+	}
+#endif
+
 	/* Core dumps may be disallowed by parent of this process; change that */
 	struct rlimit core_limits;
 	core_limits.rlim_cur = core_limits.rlim_max = RLIM_INFINITY;

--- a/janus.c
+++ b/janus.c
@@ -23,6 +23,7 @@
 #include <getopt.h>
 #include <sys/resource.h>
 #include <unistd.h>
+#include <errno.h>
 #ifdef __linux__
 #include <sys/prctl.h>
 #endif
@@ -4196,10 +4197,20 @@ gint main(int argc, char *argv[])
 	 * is SIGKILL'd, the kernel sends us SIGKILL too, instead of leaving this
 	 * janus orphaned to init and running forever. On long WAN-offline runs
 	 * such orphaned janus (and their unreaped children) accumulate until the
-	 * process/thread limit is exhausted. getppid()==1 closes the race where
-	 * the parent already died before PDEATHSIG was armed. */
-	prctl(PR_SET_PDEATHSIG, SIGKILL);
-	if(getppid() == 1) {
+	 * process/thread limit is exhausted.
+	 * Comparing the PPID across the prctl() closes the race where the parent
+	 * dies in that window, in which case PDEATHSIG would never fire. Note we
+	 * must not test getppid()==1 instead: that would also kill janus whenever
+	 * it is legitimately started by PID 1 (systemd, container init), and it
+	 * would miss reparenting to a subreaper that is not PID 1. */
+	pid_t parent_pid = getppid();
+	if(prctl(PR_SET_PDEATHSIG, SIGKILL) != 0) {
+		g_print("Warning: could not arm PR_SET_PDEATHSIG (%s); this janus may outlive its parent\n",
+			g_strerror(errno));
+	} else if(getppid() != parent_pid) {
+		/* Reparented while arming: the parent is already gone, so the signal
+		 * we just armed will never be delivered. Exit instead of orphaning. */
+		g_print("Parent process exited before PR_SET_PDEATHSIG was armed, quitting\n");
 		exit(1);
 	}
 #endif


### PR DESCRIPTION
# fix: 親(webrtc)死亡時に janus も終了するよう PR_SET_PDEATHSIG を設定

対象リポジトリ: **janus-gateway**（SafieDev fork）
ブランチ: `fix/webrtc-orphan-pdeathsig` → ベース **`dev/p2p_video_data`**（`68abb5db`）
HEAD: `94e062cd`（2 commits / `janus.c` のみ +28 行）

連動 PR:
- SafieEdgeAppFramework `fix/webrtc-orphan-pdeathsig` → `feature/sfdev_make`
- SafieDeviceCoreSDK `fix/webrtc-plugin-respawn-leak` → `main`
- spyderClient `fix/fork_storm` → `lh_main`

**マージ順序**: 本 PR を最初にマージし、以降 framework → core_sdk → 親 の順にポインタを繰り上げる。

**開発テスト完了、マージ可能です。** 実績と未実施項目の切り分けは下記「テスト観点と実施状況」を参照してください。本 PR は他 3 PR に依存しません（janus は core_sdk 配下のサブモジュールですが、本 PR 自体はポインタ更新を含まないため独立してマージできます）。

**マージ後のお願い**: マージ後の SHA を `core_sdk` 側 PR（#22）のポインタ張り替えに使います。squash/rebase で SHA が変わるため、マージ後にご連絡ください。

## 背景
STS 長時間 WAN オフライン検証で、プロセス/スレッド枯渇による EAGAIN 多発を調査。実機で **孤児 janus（と未回収の子）が大量に残存**し、資源枯渇の一因になっていた。

## 根本原因
janus は webrtc エッジアプリの子として起動される。**webrtc が exit / SIGKILL されると janus は init へ孤児化して走り続ける**。オフライン中は janus 自体も起動失敗（`janus_streaming_create_rtp_source` / `janus_pfunix_init` エラー）を繰り返しており、孤児 janus が蓄積して枯渇を助長していた。

## 変更点（コミット単位）

### `4a60f5e8` PR_SET_PDEATHSIG を設定
`janus.c` の `main()` 冒頭（Linux 限定）で `prctl(PR_SET_PDEATHSIG, SIGKILL)` を設定。親（webrtc）死亡時に kernel が janus へ SIGKILL を送り、**孤児 janus を残さない**。include に `<sys/prctl.h>` / `<unistd.h>` / `<errno.h>` を追加。

### `94e062cd` 孤児判定を PPID 変化検知へ（レビュー指摘対応）
当初は arm 前に親が死んでいたレースを `getppid()==1` で拾っていたが、これは二重に誤っていた。

- **過剰**: systemd やコンテナの PID 1 直下で正常起動した janus まで即終了させる
- **不十分**: `PR_SET_CHILD_SUBREAPER` 配下では reparent 先が PID 1 にならず、閉じたかったレースを検知できない

arm 前後の PPID 比較に変更し、あわせて `prctl()` 自体の失敗も検知するようにした。

```c
#ifdef __linux__
	pid_t parent_pid = getppid();
	if(prctl(PR_SET_PDEATHSIG, SIGKILL) != 0) {
		g_print("Warning: could not arm PR_SET_PDEATHSIG (%s); this janus may outlive its parent\n",
			g_strerror(errno));
	} else if(getppid() != parent_pid) {
		/* arm 中に reparent された = 親は既に死亡。arm したシグナルは永久に来ない */
		g_print("Parent process exited before PR_SET_PDEATHSIG was armed, quitting\n");
		exit(1);
	}
#endif
```

**本番挙動への影響はない。** janus の親（webrtc EdgeApp）は生存しているため、旧版・新版とも「exit しない」に落ちる。PDEATHSIG を arm する行自体は変更していないので、孤児化防止の機構は同一。

## 検証
- **ビルド**: 親リポジトリ（`00388be11`）経由で `sfdev_make qnap` / `sfdev_make qnap_deepx` の 2 ターゲット成功、`error:` 0 件。
- **正常系**（webrtc が生きている間）は挙動不変。親死亡時のみ発火。
- **長時間オフライン soak（完了・合格）**: 親 `3ad721acc` = 本リポジトリ `4a60f5e8` 時点のビルドで実施。**`4a60f5e8` の PDEATHSIG がまさに検証対象**。

  実機 QMGAC02357V（カメラ 49 台）、eth0 物理抜線、**実測 8/14 17:15 → 8/17 09:47 = 約 64.5 時間**。1 分周期 cron 監視の **4,145 サンプル / 欠測なし**の曲線で判定:

  ```
  zjanus_max  = 0    ← ゾンビ janus は全区間で一度も 0 を超えず
  orphan_max  = 0    ← 孤児 webrtc も同上
  ORPHAN! / ZOMBIE! / GW_DOWN! = 全て 0 件
  ```

  **ゾンビ janus が全区間 0** が本コミットの直接の成果です。旧 FW では同種の負荷でゾンビ janus が 3,438 個まで蓄積していました（親 webrtc が `system("kill -9")` で帯域外 kill するため waitpid されずゾンビ化していた経路）。終了時も **janus : webrtc : safiecam = 49 : 49 : 49** でカメラ台数と 1:1:1。

- **soak が検証していない範囲（明示）**: 上記試験の検体は `4a60f5e8` であり、**本 PR の HEAD `94e062cd` は soak されていません**。ただし `94e062cd` は本番では挙動不変です（janus の親である webrtc EdgeApp が生存している限り、旧 `getppid()==1` 版・新 PPID 比較版とも「exit しない」に落ちる。PDEATHSIG を arm する行自体は無変更）。差分が効くのは PID 1 直下起動と subreaper 配下だけなので、上記テスト観点の T4-b（PID 1 直下で即終了しないこと、10 分程度）で担保できます。

## テスト観点と実施状況

検体の別に注意してください。**`4a60f5e8` は 64.5h 実機試験済み、`94e062cd` は未実施**です。

### ✅ 実績あり（検体 = `4a60f5e8`）

| 観点 | 結果 | 根拠 |
|---|---|---|
| ゾンビ janus が蓄積しないこと | **`zjanus_max = 0`**（全 4,145 サンプル） | 64.5h 物理抜線 soak。旧 FW は 3,438 個まで蓄積 |
| 親死亡時に janus が道連れで終了すること | 即カスケード死を確認 | PhaseA-1（safiecam kill → 配下 webrtc/janus） |
| PDEATHSIG が誤発火しないこと | ライブ視聴中 4 台の janus が 90 秒生存継続、誤発火 0 | PhaseA-2 |
| janus プロセス数がカメラ台数で頭打ちになること | **janus : webrtc : safiecam = 49 : 49 : 49** | 64.5h soak 終了時スナップショット |
| Linux 限定（`#ifdef __linux__`）で他プラットフォームのビルドに影響しないこと | error 0 | `sfdev_make qnap` / `qnap_deepx`（親 `00388be11`） |

### ⏳ 検体 = `94e062cd`（2026-08-17 実機テスト実施済み・残 1 点）

`94e062cd` は**本番挙動不変**です（janus の親である webrtc EdgeApp が生存している限り、旧 `getppid()==1` 版・新 PPID 比較版とも「exit しない」に落ちる。PDEATHSIG を arm する行自体は無変更）。差分が効くのは PID 1 直下起動と subreaper 配下だけです。

**実施済み（`94e062cd` 込みビルド `00388be11` を実機に導入して確認）**

| 観点 | 結果 | 根拠 |
|---|---|---|
| 誤終了を起こさないこと（本変更が持ち込む唯一のリスク） | **本番 49 インスタンス + staging AI 機 1 インスタンス = 計 50 が正常稼働** | 本番 QMGAC02357V / staging AI 機 QW4W619543J |
| 親死亡時のカスケード終了が維持されていること | safiecam pid=1668 を `kill -9` → 配下 webrtc pid=15693 が終了、孤児 0、70 秒後に 49 台へ自動復帰 | 本番実機 |
| ビルドへの影響が無いこと | error 0 | `sfdev_make qnap` / `qnap_deepx` / `qnap_deepx IS_STAGING=1` |

**未実施（残 1 点）**

| 観点 | 手順 | 状態 |
|---|---|---|
| PID 1 直下で即終了しないこと ← `getppid()==1` 版で壊れていた唯一の挙動 | PID 1 を親にできる環境で janus を直接起動 | **未実施** |

検証機（plain qnap）には PID 1 を親にする手段がありません。ただしこの変更は `getppid()==1` を**撤去**するもので旧実装より安全側であり、**未検証なのは「改善が効くこと」であって「退行が無いこと」ではありません**（退行の不在は上表の 50 インスタンス稼働で確認済み）。この 1 点を許容できればマージ可能と考えます。