### PR TITLE
Fix/turn dns reresolve

### DIFF
--- a/ice.c
+++ b/ice.c
@@ -52,6 +52,12 @@ static char *janus_turn_type_name = NULL;
 static char *janus_turn_server_host_name = NULL;
 static char *janus_turn_server = NULL;
 static uint16_t janus_turn_port = 0;
+/* 最後に TURN サーバのアドレスを解決した時刻(monotonic, usec)。0 = 未解決。
+   同一設定でも TTL 経過後は DNS を再解決するために使う。 */
+static gint64 janus_turn_resolved_monotonic = 0;
+/* TURN サーバ名を再解決する間隔。janus プロセスは数週間生き続けるため、
+   TURN サーバ入れ替え(DNS 変更)に追従できないと古い IP を掴み続けてしまう。 */
+#define JANUS_TURN_DNS_TTL_SEC 300
 static char *janus_turn_user = NULL, *janus_turn_pwd = NULL;
 static NiceRelayType janus_turn_type = NICE_RELAY_TYPE_TURN_UDP;
 
@@ -1182,7 +1188,11 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 		return -1;
 	}
 
-	if (janus_turn_server_host_name 
+	/* 設定が同一かどうかと、DNS を再解決すべきかどうかは別問題として扱う。
+	   以前は同一設定なら常に早期 return していたため、TURN サーバが入れ替わって
+	   DNS から旧アドレスが削除されても、稼働中の janus は古い IP を掴み続けていた。 */
+	gboolean same_turn_info = FALSE;
+	if (janus_turn_server_host_name
 		&& janus_turn_port
 		&& janus_turn_type_name
 		&& janus_turn_user
@@ -1195,9 +1205,21 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 			&& !strcasecmp(turn_pwd, janus_turn_pwd)
 		)
 		{
-			JANUS_LOG(LOG_INFO, "same TURN info has been set\n");
-			return 0;
+			same_turn_info = TRUE;
 		}
+	}
+
+	gint64 now_monotonic = janus_get_monotonic_time();
+	if (same_turn_info
+		&& janus_turn_server != NULL
+		&& janus_turn_resolved_monotonic > 0
+		&& (now_monotonic - janus_turn_resolved_monotonic) <
+			(gint64)JANUS_TURN_DNS_TTL_SEC * G_USEC_PER_SEC)
+	{
+		JANUS_LOG(LOG_INFO, "same TURN info has been set (resolved %" G_GINT64_FORMAT "s ago, keep %s:%u)\n",
+			(now_monotonic - janus_turn_resolved_monotonic) / G_USEC_PER_SEC,
+			janus_turn_server, janus_turn_port);
+		return 0;
 	}
 
 	/* Resolve address to get an IP */
@@ -1210,18 +1232,31 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 		JANUS_LOG(LOG_ERR, "Could not resolve %s...\n", turn_server);
 		if(res)
 			freeaddrinfo(res);
+		if(same_turn_info && janus_turn_server != NULL) {
+			/* 設定は変わっておらず、以前に解決したアドレスがある。DNS の一時障害で
+			   セッション作成を失敗させないよう、既存アドレスを維持して成功扱いにする。 */
+			JANUS_LOG(LOG_WARN, "keep previously resolved TURN address %s:%u\n",
+				janus_turn_server, janus_turn_port);
+			return 0;
+		}
 		return -1;
 	}
 	freeaddrinfo(res);
 
 	JANUS_LOG(LOG_INFO, "getaddrinfo done\n");
 
+	const char *resolved = janus_network_address_string_from_buffer(&addr_buf);
+	if(janus_turn_server != NULL && resolved != NULL && strcmp(janus_turn_server, resolved) != 0) {
+		JANUS_LOG(LOG_INFO, "TURN address of %s changed: %s -> %s\n",
+			turn_server, janus_turn_server, resolved);
+	}
 	g_free(janus_turn_server);
-	janus_turn_server = g_strdup(janus_network_address_string_from_buffer(&addr_buf));
+	janus_turn_server = g_strdup(resolved);
 	if(janus_turn_server == NULL) {
 		JANUS_LOG(LOG_ERR, "Could not resolve %s...\n", turn_server);
 		return -1;
 	}
+	janus_turn_resolved_monotonic = now_monotonic;
 	janus_turn_port = turn_port;
 	JANUS_LOG(LOG_INFO, "  >> %s:%u\n", janus_turn_server, janus_turn_port);
 	g_free(janus_turn_user);

--- a/ice.c
+++ b/ice.c
@@ -69,13 +69,22 @@ static uint16_t janus_turn_port = 0;
    ただしこの状態では上記のブロックが create ごとに起きる点は残っている
    (DNS 障害が janus 起動直後と重なった場合に限られる)。 */
 static gint64 janus_turn_attempted_monotonic = 0;
-/* 差し替え前の janus_turn_server を 1 世代だけ保持する。
-   janus_turn_server / user / pwd は janus_ice_setup_local() から
-   nice_agent_set_relay_info() へ渡され、これは requests スレッドとは別の
-   タスクプールスレッドで動く。解放と再代入の隙間で読まれると use-after-free に
-   なるため、変更時は旧ポインタを即解放せず次の変更まで持ち越す。
-   保持するのは常に 1 本だけなのでリークにはならない。 */
+/* 差し替え前のポインタを 1 世代だけ保持する。
+   janus_turn_server / janus_turn_user / janus_turn_pwd は janus_ice_setup_local() から
+   nice_agent_set_relay_info() へ渡され(ice.c の同関数内)、これは create を処理する
+   requests スレッドとは別のタスクプールスレッドで動く。解放と再代入の隙間で読まれると
+   use-after-free になるため、変更時は旧ポインタを即解放せず次の変更まで持ち越す。
+   janus_turn_type_name / janus_turn_server_host_name は現状 requests スレッド内の
+   比較にしか使わないが、公開アクセサ(janus_ice_get_turn_*)があり将来別スレッドから
+   読まれうるため同じ扱いに揃える。
+   各ポインタにつき保持は常に 1 本だけなのでリークにはならない。
+   nice_agent_set_relay_info は渡された文字列を内部で複製するため、読み出しの寿命は
+   その呼び出し中に限られる。1 世代あれば十分。 */
 static char *janus_turn_server_prev = NULL;
+static char *janus_turn_user_prev = NULL;
+static char *janus_turn_pwd_prev = NULL;
+static char *janus_turn_type_name_prev = NULL;
+static char *janus_turn_server_host_name_prev = NULL;
 /* TURN サーバ名を再解決する間隔。janus プロセスは数週間生き続けるため、
    TURN サーバ入れ替え(DNS 変更)に追従できないと古い IP を掴み続けてしまう。 */
 #define JANUS_TURN_DNS_TTL_SEC 300
@@ -1312,19 +1321,33 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 	   nice_agent_set_relay_info() へ渡されるため競合の窓になる。変わったときだけ更新する。
 	   (旧実装は解放せずに g_strdup していたため、変わる度にリークもしていた) */
 	if(!same_turn_info) {
+		/* いずれも別スレッドから読まれうるため即解放せず 1 世代持ち越す(上の宣言参照)。
+		   確保に失敗した場合は旧ポインタを維持したまま先へ進む(NULL を掴ませない)。 */
 		janus_turn_port = turn_port;
-		g_free(janus_turn_user);
-		janus_turn_user = NULL;
-		if(turn_user)
-			janus_turn_user = g_strdup(turn_user);
-		g_free(janus_turn_pwd);
-		janus_turn_pwd = NULL;
-		if(turn_pwd)
-			janus_turn_pwd = g_strdup(turn_pwd);
-		g_free(janus_turn_type_name);
-		janus_turn_type_name = g_strdup(turn_type);
-		g_free(janus_turn_server_host_name);
-		janus_turn_server_host_name = g_strdup(turn_server);
+		char *newUser = turn_user ? g_strdup(turn_user) : NULL;
+		if(turn_user == NULL || newUser != NULL) {
+			g_free(janus_turn_user_prev);
+			janus_turn_user_prev = janus_turn_user;
+			janus_turn_user = newUser;
+		}
+		char *newPwd = turn_pwd ? g_strdup(turn_pwd) : NULL;
+		if(turn_pwd == NULL || newPwd != NULL) {
+			g_free(janus_turn_pwd_prev);
+			janus_turn_pwd_prev = janus_turn_pwd;
+			janus_turn_pwd = newPwd;
+		}
+		char *newTypeName = g_strdup(turn_type);
+		if(newTypeName != NULL) {
+			g_free(janus_turn_type_name_prev);
+			janus_turn_type_name_prev = janus_turn_type_name;
+			janus_turn_type_name = newTypeName;
+		}
+		char *newHostName = g_strdup(turn_server);
+		if(newHostName != NULL) {
+			g_free(janus_turn_server_host_name_prev);
+			janus_turn_server_host_name_prev = janus_turn_server_host_name;
+			janus_turn_server_host_name = newHostName;
+		}
 	}
 	/* port の更新後に出す(初回や port 変更時に古い値を表示しないため) */
 	JANUS_LOG(LOG_INFO, "  >> %s:%u\n", janus_turn_server, janus_turn_port);

--- a/ice.c
+++ b/ice.c
@@ -1269,9 +1269,13 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 			   設定が変わっていても待たせるが、TURN アドレスが無い状態では relay 候補を
 			   出せず挙動は変わらないため、遅延は最大 JANUS_TURN_DNS_RETRY_SEC で済む。 */
 			if (from_last_attempt < (gint64)JANUS_TURN_DNS_RETRY_SEC * G_USEC_PER_SEC) {
+				/* 意図したバックオフであり異常ではない。呼び出し元(janus.c)は戻り値が
+				   負なら LOG_FATAL を出すため、-1 を返すと create ごとに致命的エラーの
+				   ログが出て誤検知になる。この分岐は状態を何も変えないので、
+				   アドレスを保持できたソフトフェイルと同じく 0 を返す。 */
 				JANUS_LOG(LOG_WARN, "TURN address of %s is not resolved yet (last resolve attempt %" G_GINT64_FORMAT "s ago), skip retry\n",
 					turn_server, from_last_attempt / G_USEC_PER_SEC);
-				return -1;
+				return 0;
 			}
 		}
 		/* 解決済みアドレスを持っていて設定が変わった場合はここに落ち、即座に再解決する。 */
@@ -1346,7 +1350,6 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 	if(!same_turn_info) {
 		/* いずれも別スレッドから読まれうるため即解放せず 1 世代持ち越す(上の宣言参照)。
 		   確保に失敗した場合は旧ポインタを維持したまま先へ進む(NULL を掴ませない)。 */
-		janus_turn_port = turn_port;
 		char *newUser = turn_user ? g_strdup(turn_user) : NULL;
 		if(turn_user == NULL || newUser != NULL) {
 			g_free(janus_turn_user_prev);
@@ -1371,6 +1374,12 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 			janus_turn_server_host_name_prev = janus_turn_server_host_name;
 			janus_turn_server_host_name = newHostName;
 		}
+		/* port は最後に更新する。先に更新すると、万一この上の確保が失敗した場合に
+		   「port だけ新しく user/pwd は古い」という混在状態になる。
+		   なお g_strdup は g_malloc 経由で、確保に失敗するとプロセスを abort する
+		   (g_try_strdup ではないため NULL は返らない)。したがって混在状態は実際には
+		   起こらないが、順序で保証しておく。 */
+		janus_turn_port = turn_port;
 	}
 	/* port の更新後に出す(初回や port 変更時に古い値を表示しないため) */
 	JANUS_LOG(LOG_INFO, "  >> %s:%u\n", janus_turn_server, janus_turn_port);

--- a/ice.c
+++ b/ice.c
@@ -1269,13 +1269,12 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 			   設定が変わっていても待たせるが、TURN アドレスが無い状態では relay 候補を
 			   出せず挙動は変わらないため、遅延は最大 JANUS_TURN_DNS_RETRY_SEC で済む。 */
 			if (from_last_attempt < (gint64)JANUS_TURN_DNS_RETRY_SEC * G_USEC_PER_SEC) {
-				/* 意図したバックオフであり異常ではない。呼び出し元(janus.c)は戻り値が
-				   負なら LOG_FATAL を出すため、-1 を返すと create ごとに致命的エラーの
-				   ログが出て誤検知になる。この分岐は状態を何も変えないので、
-				   アドレスを保持できたソフトフェイルと同じく 0 を返す。 */
+				/* 意図したバックオフであり異常ではない。専用の戻り値で「未解決だが
+				   エラーではない」ことを表す。0 を返すと TURN が設定できたと誤解され、
+				   -1 を返すと呼び出し元が致命的エラーとして扱ってしまう。 */
 				JANUS_LOG(LOG_WARN, "TURN address of %s is not resolved yet (last resolve attempt %" G_GINT64_FORMAT "s ago), skip retry\n",
 					turn_server, from_last_attempt / G_USEC_PER_SEC);
-				return 0;
+				return JANUS_ICE_TURN_RETRY_LATER;
 			}
 		}
 		/* 解決済みアドレスを持っていて設定が変わった場合はここに落ち、即座に再解決する。 */

--- a/ice.c
+++ b/ice.c
@@ -1202,6 +1202,17 @@ int janus_ice_set_stun_server(gchar *stun_server, uint16_t stun_port) {
 	return 0;
 }
 
+/* TURN 設定の比較。NULL 同士は「同一」、片方だけ NULL は「不一致」とする。
+   資格情報を持たない TURN 構成では turn_user / turn_pwd が NULL で渡り得るため、
+   strcasecmp を直接呼ぶと NULL 参照になる。この関数内の他の箇所も
+   turn_user ? g_strdup(turn_user) : NULL のように NULL を想定しており、
+   比較だけが想定していなかった。 */
+static gboolean janus_turn_str_equal(const char *a, const char *b) {
+	if(a == NULL || b == NULL)
+		return (a == b) ? TRUE : FALSE;
+	return (strcasecmp(a, b) == 0) ? TRUE : FALSE;
+}
+
 int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *turn_type, gchar *turn_user, gchar *turn_pwd) {
 	if(turn_server == NULL)
 		return 0;	/* No initialization needed */
@@ -1224,18 +1235,19 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 	/* 設定が同一かどうかと、DNS を再解決すべきかどうかは別問題として扱う。
 	   以前は同一設定なら常に早期 return していたため、TURN サーバが入れ替わって
 	   DNS から旧アドレスが削除されても、稼働中の janus は古い IP を掴み続けていた。 */
+	/* 「保存済みか」は host_name / port / type_name で判定する。user / pwd を
+	   条件に含めると、資格情報を持たない TURN 構成で same_turn_info が常に偽になり、
+	   TTL による再解決スキップも「変わらなければ差し替えない」も効かなくなる。 */
 	gboolean same_turn_info = FALSE;
 	if (janus_turn_server_host_name
 		&& janus_turn_port
-		&& janus_turn_type_name
-		&& janus_turn_user
-		&& janus_turn_pwd)
+		&& janus_turn_type_name)
 	{
-		if (!strcasecmp(turn_server, janus_turn_server_host_name)
+		if (janus_turn_str_equal(turn_server, janus_turn_server_host_name)
 			&& turn_port == janus_turn_port
-			&& !strcasecmp(turn_type, janus_turn_type_name)
-			&& !strcasecmp(turn_user, janus_turn_user)
-			&& !strcasecmp(turn_pwd, janus_turn_pwd)
+			&& janus_turn_str_equal(turn_type, janus_turn_type_name)
+			&& janus_turn_str_equal(turn_user, janus_turn_user)
+			&& janus_turn_str_equal(turn_pwd, janus_turn_pwd)
 		)
 		{
 			same_turn_info = TRUE;

--- a/ice.c
+++ b/ice.c
@@ -53,30 +53,30 @@ static char *janus_turn_server_host_name = NULL;
 static char *janus_turn_server = NULL;
 static uint16_t janus_turn_port = 0;
 /* 最後に TURN サーバ名の解決を試行した時刻(monotonic, usec)。0 = 未試行。
-   同一設定でも TTL 経過後は DNS を再解決するために使う。
+   「最後に解決できた時刻」ではなく「最後に getaddrinfo のコストを払った時刻」であり、
+   成功・失敗で扱いを分けない。janus_ice_set_turn_server は create を処理する単一の
+   requests スレッドで動くため、リゾルバが無応答だとそのスレッドがタイムアウト分だけ
+   ブロックし、keepalive や destroy を含む janus のリクエスト処理全体が停滞する。
+   再試行の頻度に上界を与えるのがこの変数の役割。
 
-   更新するのは次の 2 つの場合。
-   1. 解決に成功したとき
-   2. 解決に失敗したが、同一設定で以前に解決したアドレスを保持できるとき
-      更新しないと、DNS 障害中は create ごとに getaddrinfo を叩き続ける。
-      janus_ice_set_turn_server は create を処理する単一の requests スレッドで動くため、
-      リゾルバのタイムアウト分だけそのスレッドがブロックし、janus のリクエスト処理
-      全体が停滞する。保持できるアドレスがあるなら、再試行は TTL 間隔で足りる。
-
-   保持できるアドレスが無い失敗(そのプロセスで一度も解決できていない場合)では
-   更新せず -1 を返す。TURN アドレスが無い間は nice_agent_set_relay_info を呼べず
-   relay 候補を出せないため、早く復帰させたい。そのため create ごとに再試行する。
-   ただしこの状態では上記のブロックが create ごとに起きる点は残っている
-   (DNS 障害が janus 起動直後と重なった場合に限られる)。 */
+   再試行の間隔は解決済みアドレスを持っているかどうかで変える。
+   - 保持している           : JANUS_TURN_DNS_TTL_SEC。TURN は使えている状態なので、
+                              サーバ入れ替えに追従できれば足りる。
+   - 一度も解決できていない : JANUS_TURN_DNS_RETRY_SEC。TURN アドレスが無い間は
+                              nice_agent_set_relay_info を呼べず relay 候補を出せない
+                              ため早く復帰させたいが、無制限に再試行すると上記の
+                              ブロックが create ごとに起きる。短い間隔で上界を作る。 */
 static gint64 janus_turn_attempted_monotonic = 0;
 /* 差し替え前のポインタを 1 世代だけ保持する。
    janus_turn_server / janus_turn_user / janus_turn_pwd は janus_ice_setup_local() から
    nice_agent_set_relay_info() へ渡され(ice.c の同関数内)、これは create を処理する
    requests スレッドとは別のタスクプールスレッドで動く。解放と再代入の隙間で読まれると
    use-after-free になるため、変更時は旧ポインタを即解放せず次の変更まで持ち越す。
-   janus_turn_type_name / janus_turn_server_host_name は現状 requests スレッド内の
-   比較にしか使わないが、公開アクセサ(janus_ice_get_turn_*)があり将来別スレッドから
-   読まれうるため同じ扱いに揃える。
+   janus_turn_server は admin API 経路(janus_process_incoming_admin_request ->
+   janus_info -> janus_ice_get_turn_server)からも読まれる。
+   janus_turn_type_name / janus_turn_server_host_name は現状この関数内の比較にしか
+   使わない(アクセサは定義済みだが ice.h に宣言がなく呼び出し元もない)。将来
+   別スレッドから読まれても壊れないよう、予防的に扱いを揃える。
    各ポインタにつき保持は常に 1 本だけなのでリークにはならない。
    nice_agent_set_relay_info は渡された文字列を内部で複製するため、読み出しの寿命は
    その呼び出し中に限られる。1 世代あれば十分。 */
@@ -88,6 +88,9 @@ static char *janus_turn_server_host_name_prev = NULL;
 /* TURN サーバ名を再解決する間隔。janus プロセスは数週間生き続けるため、
    TURN サーバ入れ替え(DNS 変更)に追従できないと古い IP を掴み続けてしまう。 */
 #define JANUS_TURN_DNS_TTL_SEC 300
+/* 一度も解決できていない状態での再試行間隔。TTL より短くして復帰を早めつつ、
+   requests スレッドがブロックする頻度に上界を与える(詳細は上の宣言参照)。 */
+#define JANUS_TURN_DNS_RETRY_SEC 30
 static char *janus_turn_user = NULL, *janus_turn_pwd = NULL;
 static NiceRelayType janus_turn_type = NICE_RELAY_TYPE_TURN_UDP;
 
@@ -1240,17 +1243,30 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 	}
 
 	gint64 now_monotonic = janus_get_monotonic_time();
-	if (same_turn_info
-		&& janus_turn_server != NULL
-		&& janus_turn_attempted_monotonic > 0
-		&& (now_monotonic - janus_turn_attempted_monotonic) <
-			(gint64)JANUS_TURN_DNS_TTL_SEC * G_USEC_PER_SEC)
-	{
-		JANUS_LOG(LOG_INFO, "same TURN info has been set (last resolve attempt %" G_GINT64_FORMAT "s ago, keep %s:%u)\n",
-			(now_monotonic - janus_turn_attempted_monotonic) / G_USEC_PER_SEC,
-			janus_turn_server, janus_turn_port);
-		return 0;
+	gint64 from_last_attempt = now_monotonic - janus_turn_attempted_monotonic;
+	if (janus_turn_attempted_monotonic > 0) {
+		if (same_turn_info && janus_turn_server != NULL) {
+			/* 解決済みアドレスがあり設定も同一。TTL 内なら再解決しない。 */
+			if (from_last_attempt < (gint64)JANUS_TURN_DNS_TTL_SEC * G_USEC_PER_SEC) {
+				JANUS_LOG(LOG_INFO, "same TURN info has been set (last resolve attempt %" G_GINT64_FORMAT "s ago, keep %s:%u)\n",
+					from_last_attempt / G_USEC_PER_SEC, janus_turn_server, janus_turn_port);
+				return 0;
+			}
+		} else if (janus_turn_server == NULL) {
+			/* このプロセスで一度も解決できていない。再試行間隔に上界を与える。
+			   設定が変わっていても待たせるが、TURN アドレスが無い状態では relay 候補を
+			   出せず挙動は変わらないため、遅延は最大 JANUS_TURN_DNS_RETRY_SEC で済む。 */
+			if (from_last_attempt < (gint64)JANUS_TURN_DNS_RETRY_SEC * G_USEC_PER_SEC) {
+				JANUS_LOG(LOG_WARN, "TURN address of %s is not resolved yet (last resolve attempt %" G_GINT64_FORMAT "s ago), skip retry\n",
+					turn_server, from_last_attempt / G_USEC_PER_SEC);
+				return -1;
+			}
+		}
+		/* 解決済みアドレスを持っていて設定が変わった場合はここに落ち、即座に再解決する。 */
 	}
+
+	/* getaddrinfo のコストを払うことが確定した。結果に関わらずここで記録する。 */
+	janus_turn_attempted_monotonic = now_monotonic;
 
 	/* Resolve address to get an IP */
 	struct addrinfo *res = NULL;
@@ -1264,15 +1280,13 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 			freeaddrinfo(res);
 		if(same_turn_info && janus_turn_server != NULL) {
 			/* 設定は変わっておらず、以前に解決したアドレスがある。DNS の一時障害で
-			   セッション作成を失敗させないよう、既存アドレスを維持して成功扱いにする。
-			   試行時刻を更新して、障害中の再試行を TTL 間隔に抑える。 */
-			janus_turn_attempted_monotonic = now_monotonic;
+			   セッション作成を失敗させないよう、既存アドレスを維持して成功扱いにする。 */
 			JANUS_LOG(LOG_WARN, "keep previously resolved TURN address %s:%u\n",
 				janus_turn_server, janus_turn_port);
 			return 0;
 		}
-		/* 維持できる既存アドレスが無い場合は失敗として返す。TURN が使えない状態なので
-		   次の create で早めに再試行させたく、試行時刻は更新しない。 */
+		/* 維持できる既存アドレスが無い場合は失敗として返す。次の create では
+		   JANUS_TURN_DNS_RETRY_SEC 間隔で再試行される。 */
 		return -1;
 	}
 	freeaddrinfo(res);
@@ -1283,9 +1297,7 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 	if(resolved == NULL) {
 		JANUS_LOG(LOG_ERR, "Could not resolve %s...\n", turn_server);
 		if(same_turn_info && janus_turn_server != NULL) {
-			/* 解決できなかったが設定は同一。既存アドレスを維持する。
-			   上と同じ理由で試行時刻を更新する。 */
-			janus_turn_attempted_monotonic = now_monotonic;
+			/* 解決できなかったが設定は同一。既存アドレスを維持する。 */
 			JANUS_LOG(LOG_WARN, "keep previously resolved TURN address %s:%u\n",
 				janus_turn_server, janus_turn_port);
 			return 0;
@@ -1314,7 +1326,6 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 		janus_turn_server_prev = janus_turn_server;
 		janus_turn_server = newServer;
 	}
-	janus_turn_attempted_monotonic = now_monotonic;
 
 	/* user / pwd / type / host は same_turn_info が真なら前回と同一と確認済み。
 	   同じ値で g_free / g_strdup を繰り返すのは無意味なうえ、これらも

--- a/ice.c
+++ b/ice.c
@@ -52,9 +52,30 @@ static char *janus_turn_type_name = NULL;
 static char *janus_turn_server_host_name = NULL;
 static char *janus_turn_server = NULL;
 static uint16_t janus_turn_port = 0;
-/* 最後に TURN サーバのアドレスを解決した時刻(monotonic, usec)。0 = 未解決。
-   同一設定でも TTL 経過後は DNS を再解決するために使う。 */
-static gint64 janus_turn_resolved_monotonic = 0;
+/* 最後に TURN サーバ名の解決を試行した時刻(monotonic, usec)。0 = 未試行。
+   同一設定でも TTL 経過後は DNS を再解決するために使う。
+
+   更新するのは次の 2 つの場合。
+   1. 解決に成功したとき
+   2. 解決に失敗したが、同一設定で以前に解決したアドレスを保持できるとき
+      更新しないと、DNS 障害中は create ごとに getaddrinfo を叩き続ける。
+      janus_ice_set_turn_server は create を処理する単一の requests スレッドで動くため、
+      リゾルバのタイムアウト分だけそのスレッドがブロックし、janus のリクエスト処理
+      全体が停滞する。保持できるアドレスがあるなら、再試行は TTL 間隔で足りる。
+
+   保持できるアドレスが無い失敗(そのプロセスで一度も解決できていない場合)では
+   更新せず -1 を返す。TURN アドレスが無い間は nice_agent_set_relay_info を呼べず
+   relay 候補を出せないため、早く復帰させたい。そのため create ごとに再試行する。
+   ただしこの状態では上記のブロックが create ごとに起きる点は残っている
+   (DNS 障害が janus 起動直後と重なった場合に限られる)。 */
+static gint64 janus_turn_attempted_monotonic = 0;
+/* 差し替え前の janus_turn_server を 1 世代だけ保持する。
+   janus_turn_server / user / pwd は janus_ice_setup_local() から
+   nice_agent_set_relay_info() へ渡され、これは requests スレッドとは別の
+   タスクプールスレッドで動く。解放と再代入の隙間で読まれると use-after-free に
+   なるため、変更時は旧ポインタを即解放せず次の変更まで持ち越す。
+   保持するのは常に 1 本だけなのでリークにはならない。 */
+static char *janus_turn_server_prev = NULL;
 /* TURN サーバ名を再解決する間隔。janus プロセスは数週間生き続けるため、
    TURN サーバ入れ替え(DNS 変更)に追従できないと古い IP を掴み続けてしまう。 */
 #define JANUS_TURN_DNS_TTL_SEC 300
@@ -1212,12 +1233,12 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 	gint64 now_monotonic = janus_get_monotonic_time();
 	if (same_turn_info
 		&& janus_turn_server != NULL
-		&& janus_turn_resolved_monotonic > 0
-		&& (now_monotonic - janus_turn_resolved_monotonic) <
+		&& janus_turn_attempted_monotonic > 0
+		&& (now_monotonic - janus_turn_attempted_monotonic) <
 			(gint64)JANUS_TURN_DNS_TTL_SEC * G_USEC_PER_SEC)
 	{
-		JANUS_LOG(LOG_INFO, "same TURN info has been set (resolved %" G_GINT64_FORMAT "s ago, keep %s:%u)\n",
-			(now_monotonic - janus_turn_resolved_monotonic) / G_USEC_PER_SEC,
+		JANUS_LOG(LOG_INFO, "same TURN info has been set (last resolve attempt %" G_GINT64_FORMAT "s ago, keep %s:%u)\n",
+			(now_monotonic - janus_turn_attempted_monotonic) / G_USEC_PER_SEC,
 			janus_turn_server, janus_turn_port);
 		return 0;
 	}
@@ -1234,11 +1255,15 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 			freeaddrinfo(res);
 		if(same_turn_info && janus_turn_server != NULL) {
 			/* 設定は変わっておらず、以前に解決したアドレスがある。DNS の一時障害で
-			   セッション作成を失敗させないよう、既存アドレスを維持して成功扱いにする。 */
+			   セッション作成を失敗させないよう、既存アドレスを維持して成功扱いにする。
+			   試行時刻を更新して、障害中の再試行を TTL 間隔に抑える。 */
+			janus_turn_attempted_monotonic = now_monotonic;
 			JANUS_LOG(LOG_WARN, "keep previously resolved TURN address %s:%u\n",
 				janus_turn_server, janus_turn_port);
 			return 0;
 		}
+		/* 維持できる既存アドレスが無い場合は失敗として返す。TURN が使えない状態なので
+		   次の create で早めに再試行させたく、試行時刻は更新しない。 */
 		return -1;
 	}
 	freeaddrinfo(res);
@@ -1246,32 +1271,63 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 	JANUS_LOG(LOG_INFO, "getaddrinfo done\n");
 
 	const char *resolved = janus_network_address_string_from_buffer(&addr_buf);
-	if(janus_turn_server != NULL && resolved != NULL && strcmp(janus_turn_server, resolved) != 0) {
-		JANUS_LOG(LOG_INFO, "TURN address of %s changed: %s -> %s\n",
-			turn_server, janus_turn_server, resolved);
-	}
-	g_free(janus_turn_server);
-	janus_turn_server = g_strdup(resolved);
-	if(janus_turn_server == NULL) {
+	if(resolved == NULL) {
 		JANUS_LOG(LOG_ERR, "Could not resolve %s...\n", turn_server);
+		if(same_turn_info && janus_turn_server != NULL) {
+			/* 解決できなかったが設定は同一。既存アドレスを維持する。
+			   上と同じ理由で試行時刻を更新する。 */
+			janus_turn_attempted_monotonic = now_monotonic;
+			JANUS_LOG(LOG_WARN, "keep previously resolved TURN address %s:%u\n",
+				janus_turn_server, janus_turn_port);
+			return 0;
+		}
 		return -1;
 	}
-	janus_turn_resolved_monotonic = now_monotonic;
-	janus_turn_port = turn_port;
+
+	/* アドレスが変わっていなければポインタを差し替えない。
+	   TTL 経過ごとに g_free / g_strdup を繰り返すと、別スレッドの
+	   nice_agent_set_relay_info() からの読み出しと競合する窓が 300 秒ごとに再発する。
+	   差し替えを「実際に変わったときだけ」に限定して窓をなくす。 */
+	if(janus_turn_server == NULL || strcmp(janus_turn_server, resolved) != 0) {
+		char *newServer = g_strdup(resolved);
+		if(newServer == NULL) {
+			/* 確保に失敗。既存アドレスは触っていないのでそのまま使い続ける。 */
+			JANUS_LOG(LOG_ERR, "failed to store resolved address of %s\n", turn_server);
+			return -1;
+		}
+		if(janus_turn_server != NULL) {
+			JANUS_LOG(LOG_INFO, "TURN address of %s changed: %s -> %s\n",
+				turn_server, janus_turn_server, resolved);
+		}
+		/* 旧ポインタは即解放しない(読み出し中のスレッドが掴んでいる可能性がある)。
+		   1 世代だけ持ち越し、次の変更時に解放する。 */
+		g_free(janus_turn_server_prev);
+		janus_turn_server_prev = janus_turn_server;
+		janus_turn_server = newServer;
+	}
+	janus_turn_attempted_monotonic = now_monotonic;
+
+	/* user / pwd / type / host は same_turn_info が真なら前回と同一と確認済み。
+	   同じ値で g_free / g_strdup を繰り返すのは無意味なうえ、これらも
+	   nice_agent_set_relay_info() へ渡されるため競合の窓になる。変わったときだけ更新する。
+	   (旧実装は解放せずに g_strdup していたため、変わる度にリークもしていた) */
+	if(!same_turn_info) {
+		janus_turn_port = turn_port;
+		g_free(janus_turn_user);
+		janus_turn_user = NULL;
+		if(turn_user)
+			janus_turn_user = g_strdup(turn_user);
+		g_free(janus_turn_pwd);
+		janus_turn_pwd = NULL;
+		if(turn_pwd)
+			janus_turn_pwd = g_strdup(turn_pwd);
+		g_free(janus_turn_type_name);
+		janus_turn_type_name = g_strdup(turn_type);
+		g_free(janus_turn_server_host_name);
+		janus_turn_server_host_name = g_strdup(turn_server);
+	}
+	/* port の更新後に出す(初回や port 変更時に古い値を表示しないため) */
 	JANUS_LOG(LOG_INFO, "  >> %s:%u\n", janus_turn_server, janus_turn_port);
-	g_free(janus_turn_user);
-	janus_turn_user = NULL;
-	if(turn_user)
-		janus_turn_user = g_strdup(turn_user);
-	g_free(janus_turn_pwd);
-	janus_turn_pwd = NULL;
-	if(turn_pwd)
-		janus_turn_pwd = g_strdup(turn_pwd);
-	/* 旧値を解放せずに g_strdup していたため、TURN 設定が変わる度にリークしていた */
-	g_free(janus_turn_type_name);
-	janus_turn_type_name = g_strdup(turn_type);
-	g_free(janus_turn_server_host_name);
-	janus_turn_server_host_name = g_strdup(turn_server);
 	return 0;
 }
 

--- a/ice.c
+++ b/ice.c
@@ -1267,7 +1267,10 @@ int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *tur
 	janus_turn_pwd = NULL;
 	if(turn_pwd)
 		janus_turn_pwd = g_strdup(turn_pwd);
+	/* 旧値を解放せずに g_strdup していたため、TURN 設定が変わる度にリークしていた */
+	g_free(janus_turn_type_name);
 	janus_turn_type_name = g_strdup(turn_type);
+	g_free(janus_turn_server_host_name);
 	janus_turn_server_host_name = g_strdup(turn_server);
 	return 0;
 }

--- a/ice.h
+++ b/ice.h
@@ -59,9 +59,10 @@ int janus_ice_test_stun_server(janus_network_address *addr, uint16_t port, uint1
 int janus_ice_set_stun_server(gchar *stun_server, uint16_t stun_port);
 /*! \brief Return value of janus_ice_set_turn_server() meaning "not resolved yet, backing off"
  * \details The TURN server name has not been resolved in this process yet, and the
- * last resolution attempt was less than JANUS_TURN_DNS_RETRY_SEC ago, so no attempt
- * was made this time. Nothing was changed (TURN is still unconfigured). This is not
- * an error: callers must not treat it as fatal. */
+ * last resolution attempt was more recent than the configured backoff interval, so no
+ * attempt was made this time. Nothing was changed (TURN is still unconfigured). This is
+ * not an error: callers must not treat it as fatal, and may simply retry on the next
+ * call. */
 #define JANUS_ICE_TURN_RETRY_LATER	(-2)
 /*! \brief Method to force Janus to use a TURN server when gathering candidates
  * @param[in] turn_server TURN server address to use

--- a/ice.h
+++ b/ice.h
@@ -57,13 +57,24 @@ int janus_ice_test_stun_server(janus_network_address *addr, uint16_t port, uint1
  * @param[in] stun_port STUN port to use
  * @returns 0 in case of success, a negative integer on errors */
 int janus_ice_set_stun_server(gchar *stun_server, uint16_t stun_port);
+/*! \brief Return value of janus_ice_set_turn_server() meaning "not resolved yet, backing off"
+ * \details The TURN server name has not been resolved in this process yet, and the
+ * last resolution attempt was less than JANUS_TURN_DNS_RETRY_SEC ago, so no attempt
+ * was made this time. Nothing was changed (TURN is still unconfigured). This is not
+ * an error: callers must not treat it as fatal. */
+#define JANUS_ICE_TURN_RETRY_LATER	(-2)
 /*! \brief Method to force Janus to use a TURN server when gathering candidates
  * @param[in] turn_server TURN server address to use
  * @param[in] turn_port TURN port to use
  * @param[in] turn_type Relay type (udp, tcp or tls)
  * @param[in] turn_user TURN username, if needed
  * @param[in] turn_pwd TURN password, if needed
- * @returns 0 in case of success, a negative integer on errors */
+ * @returns 0 in case of success, meaning a TURN address is configured. This includes
+ * the case where a transient DNS failure was ignored and the previously resolved
+ * address is kept.
+ * JANUS_ICE_TURN_RETRY_LATER when the name is not resolved yet and the resolution
+ * was skipped by the backoff; nothing was changed and this is not an error.
+ * Another negative integer on errors. */
 int janus_ice_set_turn_server(gchar *turn_server, uint16_t turn_port, gchar *turn_type, gchar *turn_user, gchar *turn_pwd);
 /*! \brief Method to force Janus to contact a TURN REST API server to get a TURN service to use when gathering candidates.
  * The TURN REST API takes precedence over any static credential passed via janus_ice_set_turn_server

--- a/janus.c
+++ b/janus.c
@@ -1102,10 +1102,11 @@ int janus_process_incoming_request(janus_request *request) {
 			   既定するのは誤りになる。資格情報を省いたまま TURN を設定すると認証で
 			   失敗して relay が張れないため、ここでは不足を設定誤りとして扱う。 */
 			if (turn_server && turn_port && turn_user && turn_pwd) {
-				/* この分岐では turn_type だけが NULL になり得る */
+				/* この分岐では turn_type だけが NULL になり得る。
+				   turn_pwd は TURN の資格情報なのでログに出さない(存在の有無だけ残す)。 */
 				JANUS_LOG(LOG_INFO, "try to set turn_server=%s, turn_port=%d, turn_type=%s, turn_user=%s, turn_pwd=%s\n", 
 						turn_server, turn_port, turn_type ? turn_type : "(null)",
-						turn_user, turn_pwd);
+						turn_user, "***");
 
 				int turn_ret = janus_ice_set_turn_server(turn_server, turn_port, turn_type, turn_user, turn_pwd);
 				if(turn_ret == JANUS_ICE_TURN_RETRY_LATER) {
@@ -1115,12 +1116,15 @@ int janus_process_incoming_request(janus_request *request) {
 					JANUS_LOG(LOG_FATAL, "Invalid TURN address %s:%u\n", turn_server, turn_port);
 				}
 			} else {
-				/* この分岐は「いずれかが NULL」のときに通るため、全て保護する */
+				/* この分岐は「いずれかが NULL」のときに通るため、全て保護する。
+				   どのフィールドが欠けているかを示すのが目的なので、turn_pwd は
+				   値ではなく有無だけを出す。LOG_FATAL は本番の既定レベルでも
+				   出力されるため、平文の資格情報を残してはならない。 */
 				JANUS_LOG(LOG_FATAL, "failed to set turn_server=%s, turn_port=%d, turn_type=%s, turn_user=%s, turn_pwd=%s\n", 
 						turn_server ? turn_server : "(null)", turn_port,
 						turn_type ? turn_type : "(null)",
 						turn_user ? turn_user : "(null)",
-						turn_pwd ? turn_pwd : "(null)");
+						turn_pwd ? "***" : "(null)");
 			}
 		}
 

--- a/janus.c
+++ b/janus.c
@@ -1092,16 +1092,35 @@ int janus_process_incoming_request(janus_request *request) {
 			char * turn_user = o_user ? json_string_value(o_user) : NULL;
 			json_t *o_pwd  = json_object_get(turn, "credential");
 			char * turn_pwd = o_pwd ? json_string_value(o_pwd) : NULL;
+			/* turn_type は省略され得るので NULL のまま %s に渡さない。
+			   printf に NULL を渡すのは未定義動作である(glibc は "(null)" を出すが
+			   規格上は保証されない)。else 側は「いずれかが NULL」のときに通るため
+			   必ず該当する。
+			   port / user / pwd を必須にしているのは意図的である。
+			   janus_ice_set_turn_server() は port 未指定を 3478 に、資格情報 NULL を
+			   許容するが、Safie の TURN は 443 で待ち受けており、省略時に 3478 へ
+			   既定するのは誤りになる。資格情報を省いたまま TURN を設定すると認証で
+			   失敗して relay が張れないため、ここでは不足を設定誤りとして扱う。 */
 			if (turn_server && turn_port && turn_user && turn_pwd) {
+				/* この分岐では turn_type だけが NULL になり得る */
 				JANUS_LOG(LOG_INFO, "try to set turn_server=%s, turn_port=%d, turn_type=%s, turn_user=%s, turn_pwd=%s\n", 
-						turn_server, turn_port, turn_type, turn_user, turn_pwd);
+						turn_server, turn_port, turn_type ? turn_type : "(null)",
+						turn_user, turn_pwd);
 
-				if(janus_ice_set_turn_server(turn_server, turn_port, turn_type, turn_user, turn_pwd) < 0) {
+				int turn_ret = janus_ice_set_turn_server(turn_server, turn_port, turn_type, turn_user, turn_pwd);
+				if(turn_ret == JANUS_ICE_TURN_RETRY_LATER) {
+					/* 未解決でバックオフ中。異常ではないので致命扱いしない
+					   (理由は janus_ice_set_turn_server 側が LOG_WARN で出している) */
+				} else if(turn_ret < 0) {
 					JANUS_LOG(LOG_FATAL, "Invalid TURN address %s:%u\n", turn_server, turn_port);
 				}
 			} else {
+				/* この分岐は「いずれかが NULL」のときに通るため、全て保護する */
 				JANUS_LOG(LOG_FATAL, "failed to set turn_server=%s, turn_port=%d, turn_type=%s, turn_user=%s, turn_pwd=%s\n", 
-						turn_server, turn_port, turn_type, turn_user, turn_pwd);
+						turn_server ? turn_server : "(null)", turn_port,
+						turn_type ? turn_type : "(null)",
+						turn_user ? turn_user : "(null)",
+						turn_pwd ? turn_pwd : "(null)");
 			}
 		}
 
@@ -5062,7 +5081,12 @@ gint main(int argc, char *argv[])
 	item = janus_config_get(config, config_nat, janus_config_type_item, "ice_keepalive_conncheck");
 	if(item && item->value)
 		janus_ice_set_keepalive_conncheck_enabled(janus_is_true(item->value));
-	if(janus_ice_set_turn_server(turn_server, turn_port, turn_type, turn_user, turn_pwd) < 0) {
+	int turn_ret = janus_ice_set_turn_server(turn_server, turn_port, turn_type, turn_user, turn_pwd);
+	if(turn_ret == JANUS_ICE_TURN_RETRY_LATER) {
+		/* 起動時はまだ一度も試行していないためここには来ない。来た場合でも
+		   バックオフは異常ではないので exit(1) してはならない。 */
+		JANUS_LOG(LOG_WARN, "TURN address of %s:%u is not resolved yet\n", turn_server, turn_port);
+	} else if(turn_ret < 0) {
 		if(!ignore_unreachable_ice_server) {
 			JANUS_LOG(LOG_FATAL, "Invalid TURN address %s:%u\n", turn_server, turn_port);
 			exit(1);


### PR DESCRIPTION
## 概要

`janus_ice_set_turn_server()` の TURN 設定管理を修正します。以下 4 点を含みます。

1. **プロセス生存中は TURN 名が一度しか解決されない** — TURN サーバ入れ替えに追従できず、**掴んだアドレスのホストが退役すると relay 依存カメラが視聴不可になる**。janus を再起動するまで復旧しない
2. **メモリリーク**（既存バグ）— TURN 設定を更新する度に 2 つの文字列が解放されず漏れていた
3. **TURN のパスワードが平文でログに出ていた**（既存バグ）— 本番の既定ログレベルでも出力される経路を含む
4. **NULL 安全性** — 資格情報を持たない TURN 構成で `strcasecmp(NULL, ...)` に至る

あわせて、上記 1 の対応で再解決を有効にすると **300 秒ごとにポインタ差し替えが発生し、既存のデータ競合の窓が周期的に再発する**ため、差し替えを「値が実際に変わったときだけ」に限定しています。

Base は `dev/p2p_video_data` です（`master` ではありません）。

## 背景

### なぜ再解決が必要か

`janus_ice_set_turn_server()` は upstream では起動時に 1 回だけ呼ばれる関数でした。Safie 版は `5138980f`（2020-03-31）でこれを **create ごとに呼ぶ**形に変えています。しかし `71b36e9b`（2023-07-21）で「設定が前回と同一なら早期 return」というガードが入ったため、**設定が変わらない限り 2 回目以降は `getaddrinfo()` に到達しません**。

STS の janus プロセスは数週間動き続けるため、その間 TURN サーバが入れ替わって DNS から旧レコードが削除されても、稼働中の janus は最初に解決した IP を掴み続けます。

これは仮説ではありません。**サーバーチームと合同で staging の TURN サーバを実際に入れ替え（旧サーバー停止）、修正版が追従して relay 視聴が成立することを確認しています。** 詳細は「検証」節に記載します。

### この修正が防ぐ障害

TURN アドレスをピン留めしたまま、**そのアドレスのホストが退役すると、その janus プロセスは relay を張れなくなります**。ICE は host / srflx 候補にフォールバックするため直接 P2P が張れるカメラは影響を受けませんが、**relay が必須のカメラは視聴不可になります**。しかも設定が変わらない限り再解決に到達しないため、**janus を再起動するまで復旧しません**。

`relay.st.safie.link` は複数の A レコードを持ちます。**ラウンドロビンによるアドレス変化それ自体は無害です** — どのアドレスも同時に有効なので、掴んだ 1 本が生きている限り relay は張れます。危険なのは**掴んだアドレスのホストが実際に退役したとき**で、このとき数週間動き続けている janus は確実に relay を失います。

### 調査中の個別障害との関係

現在追っている視聴不可障害（カメラ単位・間欠的・janus 稼働日数とともに 0% → 50% に悪化）は、**この経路の症状とは一致しません**。ピン留めが原因であれば、そのプロセス上の relay 依存カメラが**一斉・突然・恒久的に**落ちるはずです。

したがって本 PR はその障害の修正ではありませんが、**独立した確実な視聴不可要因を除去するもの**です。

### なぜ再試行に上界が必要か

`janus_ice_set_turn_server()` は create を処理する **単一の requests スレッド**で動きます。リゾルバが無応答だとこのスレッドが `getaddrinfo()` のタイムアウト分ブロックし、その間 keepalive や destroy を含む janus のリクエスト処理全体が停滞します。

実機で DNS を黒穴にして計測したところ、**`getaddrinfo()` の失敗までに約 10 秒**かかっていました（検証節のログで、314 秒経過時点の試行が 00:40:39 に始まり、失敗ログが 00:40:49 に出ています）。再解決を無条件に有効化すると、DNS 障害中は **create ごとに 10 秒のブロック**が発生します。

この負のケースを実施して初めて、**10 秒のスレッドブロックと、それに起因する `invalid_param` によるセッション作成失敗**が観測されました。正のケース（サーバー入れ替えへの追従）だけを測っていた段階では見えなかった実害です。`JANUS_TURN_DNS_RETRY_SEC` によるバックオフと、解決失敗時に**旧アドレスを維持して成功扱いにする**扱いは、いずれもこの観測が根拠です。

そのため再試行間隔に上界を設けています。

| 状態 | 間隔 | 理由 |
|---|---|---|
| 解決済みアドレスを保持している | `JANUS_TURN_DNS_TTL_SEC` = 300 秒 | TURN は使えている。サーバ入れ替えに追従できれば足りる |
| このプロセスで一度も解決できていない | `JANUS_TURN_DNS_RETRY_SEC` = 30 秒 | relay 候補を出せないので早く復帰したいが、ブロック頻度に上界が必要 |

## 変更内容

| コミット | 内容 |
|---|---|
| `53db46a8` | 同一設定でも TTL 経過後は再解決する。DNS 一時障害時は旧アドレスを維持して成功扱いにする |
| `6b1e3c78` | **リーク修正**: `janus_turn_type_name` / `janus_turn_server_host_name` を解放せずに `g_strdup` していた |
| `5feee01d` | 解決結果が前回と同一ならポインタを差し替えない（競合の窓をなくす） |
| `37999ba4` | 差し替える場合も旧ポインタを即解放せず **1 世代保持**する（読み出し中のスレッドに UAF を起こさせない） |
| `4e48c2d2` | 未解決状態での再試行に上界（30 秒）を与える |
| `a80becdb` | 比較を NULL 安全にする。`same_turn_info` の判定条件から `user` / `pwd` を外す |
| `bb6f72be` | バックオフを致命扱いにしない。`janus_turn_port` の更新を最後に回す |
| `7e0764f8` | `JANUS_ICE_TURN_RETRY_LATER` (-2) を導入し、呼び出し元 2 箇所を非致命扱いにする |
| `bb8eb915` | **`turn_pwd` をログに出さない** |

### リーク（`6b1e3c78`）

旧実装は以下のとおりで、`janus_turn_type_name` と `janus_turn_server_host_name` に `g_free` がありません。

```c
janus_turn_type_name = g_strdup(turn_type);
janus_turn_server_host_name = g_strdup(turn_server);
```

`janus_turn_user` / `janus_turn_pwd` には `g_free` があるため、**この 2 つだけが漏れていました**。設定変更の度に漏れる量なので大きくはありませんが、明確なバグです。

### パスワードのログ出力（`bb8eb915`）

`turn_pwd` が 2 箇所で平文出力されていました。

- 成功側は `LOG_INFO` — 本番の既定 `--debug-level=2` では出ませんが、デバッグ有効化中は残ります
- **失敗側は `LOG_FATAL`** — 本番の既定レベルでも出力されます

`5138980f`（2020-03-31）から存在していた経路です。値ではなく有無だけを出す形（`"***"` / `"(null)"`）に変更しました。

あわせて `turn_type` は省略され得るため、`%s` に NULL を渡さないよう保護しています（glibc は `"(null)"` を出しますが規格上の保証はありません）。

### NULL 安全性（`a80becdb`）

同一判定は `strcasecmp` を直接呼んでいたため、資格情報なしの TURN 構成（`turn_user` / `turn_pwd` が NULL）で NULL 参照になります。同じ関数内の他の箇所は `turn_user ? g_strdup(turn_user) : NULL` のように NULL を想定しており、**比較だけが想定していませんでした**。

さらに旧実装は `janus_turn_user && janus_turn_pwd` を「保存済みか」の判定に含めていたため、資格情報なしの構成では `same_turn_info` が常に偽になり、TTL によるスキップも「変わらなければ差し替えない」も効きません。判定を `host_name` / `port` / `type_name` に限定しました。

### データ競合の窓（`5feee01d` / `37999ba4`）

`janus_turn_server` / `janus_turn_user` / `janus_turn_pwd` は `janus_ice_setup_local()` から `nice_agent_set_relay_info()` へ渡されます。`janus_ice_setup_local()` は requests スレッド（`janus_process_incoming_request` 内、本ブランチでは `janus.c:1565`）と **タスクプールスレッド**（`janus_plugin_handle_sdp` 経由、`janus.c:3769`）の両方から到達可能です。

つまり `g_free` → `g_strdup` の隙間で別スレッドに読まれると use-after-free になります。これは `5138980f` が「起動時 1 回」の関数を create ごとに呼ぶ形に変えた時点で生まれた既存の競合で、`71b36e9b` の早期 return がその頻度を下げていました。

本 PR で再解決を有効にすると、**この窓が 300 秒ごとに再発します**。そこで:

- **差し替えを実際に値が変わったときだけに限定** — 通常運用ではポインタが動かない
- **差し替える場合も旧ポインタを 1 世代保持** — 読み出し中のスレッドが掴んでいても解放されない

`nice_agent_set_relay_info()` は渡された文字列を内部で複製するため、読み出しの寿命はその呼び出し中に限られます。1 世代あれば足ります。各ポインタにつき保持は常に 1 本だけなのでリークにはなりません。

## 検証

実機（GW `sf-TRAIL-STATION` + カメラ `sts-FD9369`、staging）で計測しました。主目的の追従はサーバーチームと合同でサーバー側の入れ替えを伴う形で、それ以外は `/etc/hosts` / DNS 黒穴による注入で実施しています。

### アドレス変更への追従（本 PR の主目的）

**サーバーチームと合同で、staging の TURN サーバを実際に入れ替えて検証しました（2026-08-26）。旧サーバーは停止させています** — つまり、旧実装がピン留めしたまま relay を失う条件そのものを作っています。

| 時刻 | 事象 |
|---|---|
| 17:53:22 | サーバー側で DNS を切り替え（旧 `54.92.74.100` → 新 `3.115.118.164`）、**旧サーバーを停止** |
| 17:56:12 | janus が追従。`TURN address of relay.st.safie.link changed: 54.92.74.100 -> 3.115.118.164` |
| 以降 | 新規セッションの **TURN 接続 7 本すべてが新 IP**。**live 4 本 + data 1 本が確立**し、`trans_stun_to_turn` に **3.4MB** の転送量 |

**janus は再起動していません。** 稼働中のプロセスが、旧サーバー停止後に新アドレスへ移り、relay 経由の視聴が成立しています。

追従までの遅れは **170 秒**でした。これは切替時点で TTL(300 秒)の残りが 170 秒だったためで、**最悪でも 300 秒 + 次の `create` までの時間**で追従します（再解決は `create` のときだけ走るため）。

旧実装はこの条件で relay 視聴が全滅します。設定が変わらない限り早期 return するので `getaddrinfo()` に到達せず、停止した `54.92.74.100` を掴み続けるためです。

#### ラウンドロビンによる自然発生の観測

上記とは別に、`/etc/hosts` を操作せず A レコードのラウンドロビンによる追従も 2 回観測しています。

```
[Tue Aug 25 21:00:50 2026] TURN address of relay.st.safie.link changed: 3.115.67.31 -> 54.168.31.20
[Wed Aug 26 ...]           TURN address of relay.st.safie.link changed: 3.115.118.164 -> 57.180.122.101
```

こちらは**被害を伴わない変化**です（A レコードはいずれも稼働中なので、掴んだ 1 本が生きている限り relay は張れます）。追従が日常的に機能していることの確認として記載します。

#### 観測にあたっての注意（レビュー時の再現手順）

- **`TURN address of ... changed` は `LOG_INFO`(4) です。** janus の既定は `--debug-level=2` なので、**本番ではこのログは出ません**。観測には `SetupDebug` で `debugLevel:4` にします（`debugLogPath` は空にする。指定すると `--libnice-debug` が付いてログが激増します）
- **`SetupDebug` は `ForkJanus()` を呼ぶ = janus 再起動です。** `janus_turn_server` が NULL に戻り旧→新の遷移が観測できなくなるため、**「ログレベルを上げる → その後に DNS を変える」順序が必須**です（1 回目の切替はこの順序を誤って捉え損ねました）
- **再解決は `create` のときだけ走ります。** 視聴が無いと 300 秒経っても再解決しないため、切替を捉えるには 60 秒ごとに create を 1 本発生させる監視が必要です

### 旧アドレスの保持と TTL 跨ぎ（DNS 黒穴）

一度解決させた状態から DNS を黒穴にし、TTL 300 秒を跨がせました。

```
[00:39:19] same TURN info has been set (last resolve attempt 234s ago, keep 3.115.118.164:443)
[00:39:39] same TURN info has been set (last resolve attempt 254s ago, keep 3.115.118.164:443)
[00:39:59] same TURN info has been set (last resolve attempt 274s ago, keep 3.115.118.164:443)
[00:40:19] same TURN info has been set (last resolve attempt 294s ago, keep 3.115.118.164:443)
[00:40:49] [ERR] Could not resolve relay.st.safie.link...
[00:40:49] [WARN] keep previously resolved TURN address 3.115.118.164:443
[00:40:59] same TURN info has been set (last resolve attempt 20s ago, keep 3.115.118.164:443)
[00:41:19] same TURN info has been set (last resolve attempt 40s ago, keep 3.115.118.164:443)
```

- 294 秒までは `getaddrinfo` を呼ばずスキップ
- 314 秒（00:40:39）で試行し、**約 10 秒ブロックして失敗**（00:40:49）
- 失敗しても **旧アドレスを維持して成功扱い** — セッション作成は失敗しない
- 試行時刻は成功・失敗に関わらず記録されるため、直後は「20s ago」に戻る

### 未解決状態での 30 秒スロットル

黒穴のまま janus を再 fork（未解決から開始）し、create を 10 秒間隔で連打しました。

`Could not resolve` が **04:35:01 と 04:35:31 のちょうど 30 秒間隔**で出力され、その間は `is not resolved yet ... skip retry` になりました。create ごとの `getaddrinfo` ブロックが起きていないことを確認しています。

### 残っているギャップ

| 未検証の主張 | 理由 |
|---|---|
| 旧実装が同条件で **relay を失うこと** | 実サーバー入れ替え試験は**修正版のみ**で実施し、旧 FW を同条件に通す対照は取っていません。ただし推論の根拠は 2 つあり弱くはありません: (a) 旧サーバーが**実際に停止していた**こと、(b) 旧実装は設定同一なら早期 return し `getaddrinfo()` に到達しないこと。停止したアドレスを掴み続ける以上 relay は張れません |
| アドレスが**同一なら差し替えない**（`5feee01d`） | 差し替えの不在を、TTL を跨いだうえで確認していません。`/etc/hosts` で固定して TTL を 2 回跨ぎ、`changed` が出ないことを確認する試験を追加実施します（所要 ~12 分、TTL 待ちが支配的） |

対照が取れていない点について: サーバー入れ替えはサーバーチームの作業を伴うため、旧 FW での再演には再度の調整が必要です。旧実装の早期 return は 5 行で読める明白な経路であり、対照の追加コストに見合わないと判断しました。

### 視聴回帰

relay 強制での視聴を含む回帰は core_sdk 側の PR とあわせて実施します。

## 既知の残課題（本 PR では対応しません）

**データ競合は完全に排除できていません。** 本 PR は窓を「値が変わったときだけ」に縮小し、旧ポインタを 1 世代保持することで UAF を回避していますが、`janus_turn_server` などを atomic に差し替える形にはなっていません。

正しい修正は「TURN 設定を immutable な struct にまとめ、ポインタを atomic に差し替える」形ですが、これは janus core の並行性を変える変更で、失敗した場合の症状が janus のハングになります。また QNAP の gcc が古く **TSan が使えない**ため、変更の正しさを実測で裏付ける手段が現時点でありません。

**本 PR は競合の頻度と危険性をいずれも下げているため、リリースとしては前進**と判断し、構造変更は follow-up に分離します。

## レビュー観点

- `janus_turn_attempted_monotonic` は「最後に解決**できた**時刻」ではなく「最後に `getaddrinfo` のコストを**払った**時刻」です。成功・失敗で扱いを分けていません（意図的）
- `janus.c` の `if (turn_server && turn_port && turn_user && turn_pwd)` は意図的に厳しくしています。`janus_ice_set_turn_server()` 自体は port 未指定を 3478 に既定し資格情報 NULL を許容しますが、Safie の TURN は 443 で待ち受けており、省略時に 3478 へ既定するのは誤りになります
- `JANUS_ICE_TURN_RETRY_LATER` を導入したのは、バックオフを 0（設定できた）でも -1（致命的エラー）でも表せないためです。呼び出し元は `janus.c` の 2 箇所（起動時・create 時）で、いずれも非致命扱いにしています
